### PR TITLE
Updating start-docker.cmd to be universal for all systems

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+start-docker.cmd text eol=lf

--- a/start-docker.cmd
+++ b/start-docker.cmd
@@ -1,21 +1,20 @@
+: <<'----'
 @echo off
+GOTO :SCRIPT
+----
+: SCRIPT
 echo ========================================
 echo Starting ServeLogic Application Stack
 echo ========================================
-echo.
-echo This will start all services:
-echo - ArangoDB Database (port 8529)
-echo - Fuseki Database (port 3030)
-echo - ServeLogic API (port 7999)
-echo - CMS Application (port 7998)
-echo - Ordering Application (port 8080)
-echo.
+echo "This will start all services:"
+echo "- ArangoDB Database (port 8529)"
+echo "- Fuseki Database (port 3030)"
+echo "- ServeLogic API (port 7999)"
+echo "- CMS Application (port 7998)"
+echo "- Ordering Application (port 8080)"
 echo Building and starting containers...
-echo.
-
-docker-compose up --build
-
-echo.
+echo ========================================
+docker compose up --build
 echo ========================================
 echo Application stack stopped
 echo ========================================


### PR DESCRIPTION
Added gitattributes to keep start-docker.cmd LF endings
Updated a few lines in start-docker.cmd so they're universally working between Windows and Linux

(Tested with WSL under Windows)
(May require chmod +x start-docker.cmd)